### PR TITLE
Clear _children collection before setting new value

### DIFF
--- a/ConsoleGUI/Controls/HorizontalStackPanel.cs
+++ b/ConsoleGUI/Controls/HorizontalStackPanel.cs
@@ -17,6 +17,8 @@ namespace ConsoleGUI.Controls
 			set
 			{
 				foreach (var child in _children) child.Dispose();
+				_children.Clear();
+				
 				foreach (var child in value) _children.Add(new DrawingContext(this, child));
 
 				Initialize();

--- a/ConsoleGUI/Controls/VerticalStackPanel.cs
+++ b/ConsoleGUI/Controls/VerticalStackPanel.cs
@@ -17,6 +17,8 @@ namespace ConsoleGUI.Controls
 			set
 			{
 				foreach (var child in _children) child.Dispose();
+				_children.Clear();
+				
 				foreach (var child in value) _children.Add(new DrawingContext(this, child));
 
 				Initialize();


### PR DESCRIPTION
When setting a new value for Children property the property is expected to contain only elements that were set, no disposed ghosts from the past